### PR TITLE
Configuração inicial do projeto para deploy no Heroku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Others
+_dev/
+_mydata/

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ flake8 = "*"
 
 [packages]
 django = "*"
+gunicorn = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6fffd33ea4c7101a8d92c3b874bdb5da45821539a073ab0c6419a65bf8387efd"
+            "sha256": "18ec5ffb09a25e214c6d5c5977e1e4b558cff4fa7d6118d616c141597d0310b3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -31,6 +31,14 @@
             ],
             "index": "pypi",
             "version": "==3.1.4"
+        },
+        "gunicorn": {
+            "hashes": [
+                "sha256:1904bb2b8a43658807108d59c3f3d56c2b6121a701161de0ddf9ad140073c626",
+                "sha256:cd4a810dd51bf497552cf3f863b575dabd73d6ad6a91075b65936b151cbf4f9c"
+            ],
+            "index": "pypi",
+            "version": "==20.0.4"
         },
         "pytz": {
             "hashes": [

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn utilrh.wsgi --log-file -


### PR DESCRIPTION
Configuração inicial do projeto para deploy no Heroku (app criada no heroku via shell, instalação do gunicorn no projeto e criação/configuração do Procfile apontando para o settings definido no wsgi. Atualizado gitignore para ignorar as pastas _dev e _mydata

`
heroku apps: create <nome-app>

pipenv install gunicorn

`

close #16 